### PR TITLE
Doesn't work unless strict mode is used

### DIFF
--- a/fixture4.js
+++ b/fixture4.js
@@ -1,0 +1,5 @@
+function foo() {
+	return require('./')();
+}
+
+module.exports = () => foo();

--- a/test.js
+++ b/test.js
@@ -3,9 +3,11 @@ import test from 'ava';
 import fixture from './fixture';
 import fixture2 from './fixture2';
 import fixture3 from './fixture3';
+import fixture4 from './fixture4';
 
 test(t => {
 	t.is(path.basename(fixture()), 'test.js');
 	t.is(path.basename(fixture2()), 'test.js');
 	t.is(path.basename(fixture3()), 'test.js');
+	t.is(path.basename(fixture4()), 'test.js');
 });


### PR DESCRIPTION
When strict mode isn't used, it incorrectly gives you the path of the current file instead of the caller file

This is just a test to demo this. I don't have a solution, as I don't think it's possible to actually detect strict mode.

You can use CallSites directly though, without strict mode it needs to be the 1st instead of 0th call site:

```
CallSites()[1].getFileName() // [1] instead of [0]
```

Maybe in future this wouldn't be a problem anyways as ES6 modules would be in strict mode by default, I think. Still a heads up in case anyone encounters this. 